### PR TITLE
Apply changes from https://github.com/casper-network/casper-node/pull/5089

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byteorder"
@@ -176,9 +176,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "casper-binary-port"
@@ -193,7 +193,7 @@ dependencies = [
  "serde",
  "strum",
  "strum_macros",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio-util",
  "tracing",
 ]
@@ -207,7 +207,7 @@ dependencies = [
  "futures",
  "gloo-utils",
  "js-sys",
- "thiserror",
+ "thiserror 2.0.11",
  "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -226,7 +226,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.11",
  "tokio",
 ]
 
@@ -263,7 +263,7 @@ dependencies = [
  "serde-map-to-array",
  "serde_bytes",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "uint",
  "untrusted",
@@ -277,9 +277,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -300,14 +300,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -336,9 +336,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -405,7 +405,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -440,15 +440,15 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.18"
+version = "0.99.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
 
 [[package]]
 name = "ecdsa"
@@ -646,7 +646,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -927,7 +927,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1157,9 +1157,9 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "schemars"
@@ -1183,7 +1183,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1241,7 +1241,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1252,14 +1252,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "indexmap 2.7.1",
  "itoa",
@@ -1346,7 +1346,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1368,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1393,7 +1393,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -1404,7 +1413,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1431,7 +1451,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1467,7 +1487,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1505,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "untrusted"
@@ -1555,7 +1575,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -1590,7 +1610,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1714,7 +1734,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["binary-port-access"]
+members = ["binary-port-access", "binary-port-access"]
 
 [package]
 name = "casper-binary-port-client"
@@ -10,14 +10,17 @@ authors = ["Rafał Chabowski <rafal@casperlabs.io>"]
 description = "CLI for Casper binary port."
 license = "Apache-2.0"
 
-[dependencies]
-casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev", features = [
-    "std-fs-io",
-] }
+[workspace.dependencies]
+casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev", default-features = false }
 casper-binary-port = { version = "1.0.0", git = "https://github.com/casper-network/casper-node", branch = "dev" }
+thiserror = "2.0.11"
+
+[dependencies]
+casper-types = { workspace = true, features = ["std-fs-io"] }
+casper-binary-port.workspace = true
+thiserror.workspace = true
 casper-binary-port-access = { path = "./binary-port-access" }
 clap = { version = "4.5.20", features = ["derive", "wrap_help"] }
-thiserror = "1.0.64"
 tokio = { version = "1.41.0", features = ["macros", "rt", "net"] }
 hex = "0.4.3"
 serde = { version = "1.0.211", features = ["derive"] }

--- a/binary-port-access/Cargo.toml
+++ b/binary-port-access/Cargo.toml
@@ -13,9 +13,9 @@ path = "src/lib.rs"
 
 # Dependencies for all compilation targets
 [dependencies]
-casper-types = { git = "https://github.com/casper-network/casper-node", branch = "dev", default-features = false }
-casper-binary-port = { git = "https://github.com/casper-network/casper-node", branch="dev" }
-thiserror = "1.0.64"
+casper-types.workspace = true
+casper-binary-port.workspace = true
+thiserror.workspace = true
 futures = "0.3.31"
 
 # Tokio is not compatible with wasm32 targets and is included here for non-wasm32

--- a/binary-port-access/src/communication/common.rs
+++ b/binary-port-access/src/communication/common.rs
@@ -2,12 +2,9 @@ use crate::Error;
 #[cfg(not(target_arch = "wasm32"))]
 use casper_binary_port::BinaryMessage;
 use casper_binary_port::{
-    BinaryRequest, BinaryRequestHeader, BinaryResponse, BinaryResponseAndRequest, PayloadEntity,
+    BinaryRequestHeader, BinaryResponse, BinaryResponseAndRequest, Command, PayloadEntity,
 };
-use casper_types::{
-    bytesrepr::{self, FromBytes, ToBytes},
-    ProtocolVersion,
-};
+use casper_types::bytesrepr::{self, FromBytes, ToBytes};
 use std::sync::atomic::AtomicU16;
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::atomic::Ordering;
@@ -20,12 +17,9 @@ use tokio::{
     time::timeout,
 };
 
-// TODO[RC]: Do not hardcode this.
-pub(crate) const SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::from_parts(2, 0, 0);
 pub(crate) const LENGTH_FIELD_SIZE: usize = 4;
 #[cfg(not(target_arch = "wasm32"))]
 const TIMEOUT_DURATION: Duration = Duration::from_secs(5);
-
 pub static COUNTER: AtomicU16 = AtomicU16::new(0);
 
 /// Establishes an asynchronous TCP connection to a specified node address.
@@ -167,7 +161,7 @@ async fn read_response(client: &mut TcpStream) -> Result<Vec<u8>, Error> {
 ///
 /// - `node_address`: A string slice that holds the address of the node to connect to,
 ///   typically in the format "hostname:28101".
-/// - `request`: An instance of `BinaryRequest` representing the request data to be sent.
+/// - `request`: An instance of `Command` representing the request data to be sent.
 ///
 /// # Returns
 ///
@@ -194,10 +188,9 @@ async fn read_response(client: &mut TcpStream) -> Result<Vec<u8>, Error> {
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) async fn send_request(
     node_address: &str,
-    request: BinaryRequest,
+    request: Command,
 ) -> Result<BinaryResponseAndRequest, Error> {
     let request_id = COUNTER.fetch_add(1, Ordering::SeqCst); // Atomically increment the counter
-
     let raw_bytes =
         encode_request(&request, request_id).expect("should always serialize a request");
     send_raw(node_address, raw_bytes, Some(request_id)).await
@@ -224,13 +217,13 @@ pub(crate) async fn send_raw(
 
 /// Encodes a binary request into a byte vector for transmission.
 ///
-/// This function serializes a `BinaryRequest` along with a specified request ID (if provided)
+/// This function serializes a `Command` along with a specified request ID (if provided)
 /// into a byte vector. The encoded data includes a header containing the protocol version,
 /// request tag, and the request ID. This byte vector can then be sent over a network connection.
 ///
 /// # Parameters
 ///
-/// - `req`: A reference to a `BinaryRequest` instance representing the request to be serialized.
+/// - `req`: A reference to a `Command` instance representing the request to be serialized.
 /// - `request_id`: An optional `u16` representing the unique identifier for the request. If not provided,
 ///   a default value of `0` is used.
 ///
@@ -250,11 +243,8 @@ pub(crate) async fn send_raw(
 ///
 /// The request ID helps in tracking requests and their corresponding responses, allowing for easier
 /// identification in asynchronous communication.
-pub(crate) fn encode_request(
-    req: &BinaryRequest,
-    request_id: u16,
-) -> Result<Vec<u8>, bytesrepr::Error> {
-    let header = BinaryRequestHeader::new(SUPPORTED_PROTOCOL_VERSION, req.tag(), request_id);
+pub(crate) fn encode_request(req: &Command, request_id: u16) -> Result<Vec<u8>, bytesrepr::Error> {
+    let header = BinaryRequestHeader::new(req.tag(), request_id);
     let mut bytes = Vec::with_capacity(header.serialized_length() + req.serialized_length());
     header.write_bytes(&mut bytes)?;
     req.write_bytes(&mut bytes)?;
@@ -348,22 +338,26 @@ pub(crate) async fn process_response(
     response_buf: Vec<u8>,
     request_id: u16,
 ) -> Result<BinaryResponseAndRequest, Error> {
-    const REQUEST_ID_START: usize = 0;
+    const REQUEST_ID_START: usize = 7;
     const REQUEST_ID_END: usize = REQUEST_ID_START + 2;
 
-    // Check if the response buffer is at least the size of the request ID
-    if response_buf.len() < REQUEST_ID_END {
+    // Deserialize the remaining response data
+    let response: BinaryResponseAndRequest = bytesrepr::deserialize_from_slice(response_buf)?;
+    let request = response.request();
+
+    // Check if the request buffer is at least the size of the request ID
+    if request.len() < REQUEST_ID_END {
         return Err(Error::Response(format!(
-                "Response buffer is too small: expected at least {} bytes, got {}. Buffer contents: {:?}",
-                REQUEST_ID_END,
-                response_buf.len(),
-                response_buf
-            )));
+                    "Response buffer is too small: expected at least {} bytes, got {}. Buffer contents: {:?}",
+                    REQUEST_ID_END,
+                    request.len(),
+                    request
+                )));
     }
 
-    // Extract Request ID from the response
+    // Extract Request ID from the request
     let response_request_id = u16::from_le_bytes(
-        response_buf[REQUEST_ID_START..REQUEST_ID_END]
+        request[REQUEST_ID_START..REQUEST_ID_END]
             .try_into()
             .expect("Failed to extract Request ID"),
     );
@@ -374,8 +368,5 @@ pub(crate) async fn process_response(
             "Request ID mismatch: expected {request_id}, got {response_request_id}"
         )));
     }
-
-    // Deserialize the remaining response data
-    let response: BinaryResponseAndRequest = bytesrepr::deserialize_from_slice(response_buf)?;
     Ok(response)
 }

--- a/binary-port-access/src/lib.rs
+++ b/binary-port-access/src/lib.rs
@@ -8,10 +8,9 @@ mod utils;
 #[cfg(not(target_arch = "wasm32"))]
 use casper_binary_port::BinaryResponse;
 use casper_binary_port::{
-    BinaryRequest, ConsensusStatus, ConsensusValidatorChanges, EraIdentifier,
-    GlobalStateQueryResult, InformationRequestTag, LastProgress, NetworkName, NodeStatus,
-    ReactorStateName, RecordId, RewardResponse, SpeculativeExecutionResult,
-    TransactionWithExecutionInfo, Uptime,
+    Command, ConsensusStatus, ConsensusValidatorChanges, EraIdentifier, GlobalStateQueryResult,
+    InformationRequestTag, LastProgress, NetworkName, NodeStatus, ReactorStateName, RecordId,
+    RewardResponse, SpeculativeExecutionResult, TransactionWithExecutionInfo, Uptime,
 };
 use casper_types::{
     bytesrepr::ToBytes, AvailableBlockRange, BlockHash, BlockHeader, BlockIdentifier,
@@ -412,7 +411,7 @@ pub async fn try_accept_transaction(
     node_address: &str,
     transaction: Transaction,
 ) -> Result<(), Error> {
-    let request = BinaryRequest::TryAcceptTransaction { transaction };
+    let request = Command::TryAcceptTransaction { transaction };
     let response = send_request(node_address, request).await?;
     check_error_code(&response)
 }
@@ -422,7 +421,7 @@ pub async fn try_speculative_execution(
     node_address: &str,
     transaction: Transaction,
 ) -> Result<SpeculativeExecutionResult, Error> {
-    let request = BinaryRequest::TrySpeculativeExec { transaction };
+    let request = Command::TrySpeculativeExec { transaction };
     let response = send_request(node_address, request).await?;
 
     check_error_code(&response)?;

--- a/binary-port-access/src/utils.rs
+++ b/binary-port-access/src/utils.rs
@@ -6,7 +6,7 @@ use crate::{communication::common::parse_response, Error};
 #[cfg(not(target_arch = "wasm32"))]
 use casper_binary_port::BinaryResponse;
 use casper_binary_port::{
-    BinaryRequest, BinaryResponseAndRequest, EraIdentifier, GetRequest, GlobalStateEntityQualifier,
+    BinaryResponseAndRequest, Command, EraIdentifier, GetRequest, GlobalStateEntityQualifier,
     GlobalStateQueryResult, GlobalStateRequest, InformationRequest, InformationRequestTag,
     RecordId, RewardResponse,
 };
@@ -19,14 +19,14 @@ use casper_types::{
 pub(crate) fn make_information_get_request(
     tag: InformationRequestTag,
     key: &[u8],
-) -> Result<BinaryRequest, Error> {
+) -> Result<Command, Error> {
     let information_request = InformationRequest::try_from((tag, key))?;
     let get_request = information_request.try_into()?;
-    Ok(BinaryRequest::Get(get_request))
+    Ok(Command::Get(get_request))
 }
 
-pub(crate) fn make_record_request(record_id: RecordId, key: &[u8]) -> BinaryRequest {
-    BinaryRequest::Get(GetRequest::Record {
+pub(crate) fn make_record_request(record_id: RecordId, key: &[u8]) -> Command {
+    Command::Get(GetRequest::Record {
         key: key.to_vec(),
         record_type_tag: record_id as u16,
     })
@@ -83,7 +83,7 @@ pub(crate) async fn global_state_item_by_state_identifier(
         path,
     };
     let global_state_request = GlobalStateRequest::new(global_state_identifier, qualifier);
-    let request = BinaryRequest::Get(GetRequest::State(Box::new(global_state_request)));
+    let request = Command::Get(GetRequest::State(Box::new(global_state_request)));
     let response = send_request(node_address, request).await?;
     check_error_code(&response)?;
     parse_response::<GlobalStateQueryResult>(response.response())


### PR DESCRIPTION
Apply changes from https://github.com/casper-network/casper-node/pull/5089

- Renamed BinaryRequest to Command
- changed BinaryResponseAndRequest so it holds responses requests raw bytes instead of derived structure

Missing : Update of example files `resources/examples/*.bin`

Getting request_id form  `BinaryResponseAndRequest`  request is a bit strange, I would have expected not to have to extract the request id from therequest but have in in `BinaryResponseHeader`



