### PR TITLE
Make it possible to initialize COUNTER with a custom value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,7 @@ dependencies = [
  "bytes",
  "casper-types",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "strum",
  "strum_macros",
@@ -224,6 +224,7 @@ dependencies = [
  "clap",
  "erased-serde",
  "hex",
+ "rand 0.9.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -243,7 +244,7 @@ dependencies = [
  "derive_more",
  "derp",
  "ed25519-dalek",
- "getrandom",
+ "getrandom 0.2.15",
  "hex",
  "hex_fmt",
  "humantime",
@@ -257,7 +258,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pem",
- "rand",
+ "rand 0.8.5",
  "schemars",
  "serde",
  "serde-map-to-array",
@@ -356,7 +357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -542,7 +543,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -580,7 +581,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -699,8 +700,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -729,7 +742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -882,7 +895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -1031,7 +1044,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1059,8 +1072,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.0",
+ "zerocopy 0.8.16",
 ]
 
 [[package]]
@@ -1070,7 +1094,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.0",
 ]
 
 [[package]]
@@ -1079,7 +1113,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.16",
 ]
 
 [[package]]
@@ -1286,7 +1330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1534,6 +1578,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,13 +1750,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.8.0",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b8c07a70861ce02bad1607b5753ecb2501f67847b9f9ada7c160fff0ec6300c"
+dependencies = [
+ "zerocopy-derive 0.8.16",
 ]
 
 [[package]]
@@ -1711,6 +1782,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5226bc9a9a9836e7428936cde76bb6b22feea1a8bfdbc0d241136e4d13417e25"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ hex = "0.4.3"
 serde = { version = "1.0.211", features = ["derive"] }
 serde_json = "1.0.132"
 erased-serde = "0.4.5"
+rand = "0.9.0"

--- a/binary-port-access/src/communication/common.rs
+++ b/binary-port-access/src/communication/common.rs
@@ -9,7 +9,6 @@ use casper_types::{
     ProtocolVersion,
 };
 use std::sync::atomic::AtomicU16;
-#[cfg(not(target_arch = "wasm32"))]
 use std::sync::atomic::Ordering;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
@@ -27,6 +26,15 @@ pub(crate) const LENGTH_FIELD_SIZE: usize = 4;
 const TIMEOUT_DURATION: Duration = Duration::from_secs(5);
 
 pub static COUNTER: AtomicU16 = AtomicU16::new(0);
+
+/// Initializes the internal request id counter to the specified value.
+///
+/// The request ids are ordinal; by default, starting at 0. This function sets
+/// the counter value to the provided id. The subsequent requests IDs will continue
+/// being ordinally numbered, starting from the provided value.
+pub fn initialize_request_id(id: u16) {
+    COUNTER.store(id, Ordering::SeqCst);
+}
 
 /// Establishes an asynchronous TCP connection to a specified node address.
 ///

--- a/binary-port-access/src/lib.rs
+++ b/binary-port-access/src/lib.rs
@@ -19,6 +19,7 @@ use casper_types::{
     GlobalStateIdentifier, Key, NextUpgrade, Peers, ProtocolVersion, PublicKey, Transaction,
     TransactionHash,
 };
+pub use communication::common::initialize_request_id;
 use communication::common::parse_response;
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) use communication::common::send_request;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,10 @@ use std::{fs::File, io::Read, process::ExitCode};
 
 use crate::error::Error;
 use args::Commands;
+use casper_binary_port_access::initialize_request_id;
 use clap::Parser;
 use information::handle_information_request;
+use rand::Rng;
 use raw::{handle_raw, OutputOption};
 use record::handle_record_request;
 use state::handle_state_request;
@@ -23,6 +25,13 @@ mod utils;
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> ExitCode {
     let args = args::Args::parse();
+
+    // The CLI is stateless and short-lived, so ordinally counting request IDs
+    // from 0 upwards will certainly bring about collisions in cases of subsequent
+    // commands being issued.
+    //
+    // To remedy this, we'll explicitly initialize the counter with a random u16 value.
+    initialize_request_id(rand::rng().random());
 
     let result = match args.commands {
         Commands::Information(req) => handle_information_request(&args.node_address, req).await,


### PR DESCRIPTION
With the changes introduced in #1 , the request ids are ordinal, counted from 0. This is problematic for the CLI, which is stateless and short-lived, as it will always attempt to send a request with id=0. This PR adds the ability to initialize the internal counter with a specified value, so that the CLI can replicate its prior behavior of randomly picking out an id. It's also useful for consumers of the binary port access library facing similar issues.

See:
```rs
fn main() {
    let args = args::Args::parse();
    casper_binary_port_access::initialize_request_id(rand::rng().random());
    let result = match args.commands {
    // go on as usual
    // ...
}
```